### PR TITLE
FileLoading: be more verbose if file not found

### DIFF
--- a/Proteomics/ProteolyticDigestion/ProteaseDictionary.cpp
+++ b/Proteomics/ProteolyticDigestion/ProteaseDictionary.cpp
@@ -1,5 +1,7 @@
 ﻿#include <iostream>
 #include <fstream>
+#include <experimental/filesystem>
+#include <stdlib.h>
 
 #include "ProteaseDictionary.h"
 #include "Protease.h"
@@ -68,9 +70,11 @@ namespace Proteomics
 #endif
             std::vector<std::string> myLines;
             std::ifstream sr(path);
+            
             if ( !sr.is_open() ) {
-                std::cout << " Could not load Protease Dictionary " << path << std::endl;
-                return dict;
+                std::string thisdir=std::experimental::filesystem::current_path().string();
+                std::cout << " Could not find Protease Dictionary " << path << " in " << thisdir << std::endl;
+                exit (-1);
             }
             
             std::string oneline;

--- a/UsefulProteomicsDatabases/PeriodicTableLoader.cpp
+++ b/UsefulProteomicsDatabases/PeriodicTableLoader.cpp
@@ -12,11 +12,19 @@
 
 #include <iostream>
 #include <fstream>
+#include <stdlib.h>
+#include <experimental/filesystem>
 
 namespace UsefulProteomicsDatabases {
 
     void PeriodicTableLoader::Load(const std::string &elementLocation) {
         std::ifstream sr(elementLocation);
+        if ( !sr.is_open() ) {
+            std::string thisdir=std::experimental::filesystem::current_path().string();
+            
+            std::cout << "Could not open file " << elementLocation << " in " << thisdir << std::endl;
+            exit (-1);
+        }
         std::string line;
         while ( getline(sr, line) ){
             if ( line.find("Atomic Number", 0) != std::string::npos ) {


### PR DESCRIPTION
print an explicit message which file could not be opened and where we were looking for it, and exit cleanly instead of segfaulting later somewhere.

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>