### PR TITLE
FileLoading: be more verbose if file not found part 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,7 @@ Test/DatabaseTests/fake1.txt
 Test/DatabaseTests/fake2.txt
 Test/DatabaseTests/fake3.txt
 Test/DatabaseTestsfake.txt
+Test/DatabaseTests/test_diagnostic_ion_mod.xml
+Test/DatabaseTests/test_neutral_loss_diagnostic_ion_mod.xml
+Test/DatabaseTests/test_neutral_loss_mod.xml
 

--- a/Test/DatabaseTests/runtest.sh
+++ b/Test/DatabaseTests/runtest.sh
@@ -18,11 +18,11 @@ fi
 
 echo " "
 echo "  TestProteomicsReadWrite"
-make TestProteomicsReadWrite
+make -s TestProteomicsReadWrite
 ./TestProteomicsReadWrite
 
 echo " "
 echo "  TestDatabaseLoaders"
-make TestDatabaseLoaders
+make -s TestDatabaseLoaders
 ./TestDatabaseLoaders
 

--- a/Test/TestFlashLFQ/runtest.sh
+++ b/Test/TestFlashLFQ/runtest.sh
@@ -5,6 +5,6 @@ fi
 
 echo " "
 echo "  TestFlashLFQ"
-make TestFlashLFQ
+make -s TestFlashLFQ
 ./TestFlashLFQ
 

--- a/Test/runtest.sh
+++ b/Test/runtest.sh
@@ -5,83 +5,83 @@ fi
 
 echo " "
 echo "  TestElementsAndIsotopes"
-make TestElementsAndIsotopes
+make -s TestElementsAndIsotopes
 ./TestElementsAndIsotopes
 
 echo " "
 echo "  TestAminoAcids"
-make TestAminoAcids
+make -s TestAminoAcids
 ./TestAminoAcids
 
 echo " "
 echo "  TestChemicalFormula"
-make TestChemicalFormula
+make -s TestChemicalFormula
 ./TestChemicalFormula
 
 echo " "
 echo "  TestModifications  "
-make TestModifications
+make -s TestModifications
 ./TestModifications
 
 echo " "
 echo "  TestDigestionMotif  "
-make TestDigestionMotif
+make -s TestDigestionMotif
 ./TestDigestionMotif
 
 echo " "
 echo "  TestPeptides  "
-make TestPeptides
+make -s TestPeptides
 ./TestPeptides
 
 echo " "
 echo "  TestPeptideWithSetMods  "
-make TestPeptideWithSetMods
+make -s TestPeptideWithSetMods
 ./TestPeptideWithSetMods
 
 echo " "
 echo "  TestFragments  "
-make TestFragments
+make -s TestFragments
 ./TestFragments
 
 echo " "
 echo "  TestMetaMorpheus"
-make TestMetaMorpheus
+make -s TestMetaMorpheus
 ./TestMetaMorpheus
 
 echo " "
 echo "  TestSpectra"
-make TestSpectra
+make -s TestSpectra
 ./TestSpectra
 
 echo " "
 echo "  TestMzML"
-make TestMzML
+make -s TestMzML
 ./TestMzML
 
 echo " "
 echo "  TestPtmListLoader"
-make TestPtmListLoader
+make -s TestPtmListLoader
 ./TestPtmListLoader
 
 echo " "
 echo "  TestModFits"
-make TestModFits
+make -s TestModFits
 ./TestModFits
 
 
 echo " "
 echo "  TestProteinProperties"
-make TestProteinProperties
+make -s TestProteinProperties
 ./TestProteinProperties
 
 echo " "
 echo "  TestProteinDigestion"
-make TestProteinDigestion
+make -s TestProteinDigestion
 ./TestProteinDigestion
 
 echo " "
 echo "  TestMgf"
-make TestMgf
+make -s TestMgf
 ./TestMgf
 
 cd DatabaseTests ; ./runtest.sh ; cd ..

--- a/UsefulProteomicsDatabases/PtmListLoader.cpp
+++ b/UsefulProteomicsDatabases/PtmListLoader.cpp
@@ -15,6 +15,7 @@
 
 #include <fstream>
 #include <iostream>
+#include <stdlib.h>
 
 using namespace Chemistry;
 using namespace MassSpectrometry;
@@ -83,6 +84,12 @@ namespace UsefulProteomicsDatabases
 
         //StreamReader uniprot_mods = StreamReader(ptmListLocation);
         std::ifstream uniprot_mods(ptmListLocation);
+        if ( !uniprot_mods.is_open() ) {
+            std::string thisdir=std::experimental::filesystem::current_path().string();
+            std::cout << " Could not find file " << ptmListLocation << " in " << thisdir << std::endl;
+            exit (-1);
+        }
+
         std::vector<std::string> modification_specification;
         
         //This block will read one complete modification entry at a time until the EOF is reached.

--- a/UsefulProteomicsDatabases/UnimodLoader.cpp
+++ b/UsefulProteomicsDatabases/UnimodLoader.cpp
@@ -16,6 +16,7 @@
 #include <iostream>
 #include <fstream>
 #include <string>
+#include <stdlib.h>
 
 namespace UsefulProteomicsDatabases
 {
@@ -51,6 +52,11 @@ namespace UsefulProteomicsDatabases
         auto deserialized = dynamic_cast<unimod_t*>(unimodSerializer->Deserialize(&tempVar));
 #endif
         std::ifstream fs (unimodLocation);
+        if ( !fs.is_open() ) {
+            std::string thisdir=std::experimental::filesystem::current_path().string();
+            std::cout << " Could not find Unimodtable " << unimodLocation << " in " << thisdir << std::endl;
+            exit (-1);
+        }
         auto deserialized = unimod(fs, xml_schema::flags::dont_validate );
 
         std::unordered_map<std::string, std::string> positionConversion =


### PR DESCRIPTION
print an explicit message which file could not be opened and where we were looking for it, and exit cleanly instead of segfaulting later somewhere.
This commit covers more files using the same approach.

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>