### PR TITLE
FileLoading: be more verbose if file not found part 3

### DIFF
--- a/Mgf/Mgf.cpp
+++ b/Mgf/Mgf.cpp
@@ -11,6 +11,7 @@
 
 #include <iostream>
 #include <fstream>
+#include <stdlib.h>
 
 using namespace MassSpectrometry;
 using namespace MzLibUtil;
@@ -45,7 +46,10 @@ namespace IO
             StreamReader sr = StreamReader(bs);
 #endif
             std::ifstream sr ( filePath );
-
+            if ( !sr.is_open() ) {
+                std::cout << "Could not open file " << filePath << std::endl;
+                exit(-1);
+            }
             std::string s;
 
             //while ((s = sr.ReadLine()) != "" && s != "BEGIN IONS")

--- a/MzIdentML/MzidIdentifications.cpp
+++ b/MzIdentML/MzidIdentifications.cpp
@@ -8,6 +8,7 @@
  */
 #include <iostream>
 #include <fstream>
+#include <stdlib.h>
 #include "MzidIdentifications.h"
 #include "mzIdentML110.h"
 #include "mzIdentML111.h"
@@ -35,6 +36,10 @@ namespace MzIdentML
 #endif
             
             std::ifstream fs = std::ifstream(mzidFile);
+            if ( !fs.is_open()) {
+                std::cout << "Could not open file " << mzidFile << std::endl;
+                exit(-1);
+            }
             dd110 =  mzIdentML110::MzIdentML (fs, xml_schema::flags::dont_validate );
             fs.close();
 
@@ -45,6 +50,10 @@ namespace MzIdentML
             try
             {
                 std::ifstream fs = std::ifstream(mzidFile);
+                if ( !fs.is_open()) {
+                    std::cout << "Could not open file " << mzidFile << std::endl;
+                    exit(-1);
+                }
                 dd111 =  mzIdentML111::MzIdentML (fs, xml_schema::flags::dont_validate );
                 fs.close();
 
@@ -53,6 +62,10 @@ namespace MzIdentML
             catch (...)
             {
                 std::ifstream fs = std::ifstream(mzidFile);
+                if ( !fs.is_open()) {
+                    std::cout << "Could not open file " << mzidFile << std::endl;
+                    exit(-1);
+                }
                 dd120 =  mzIdentML120::MzIdentML (fs, xml_schema::flags::dont_validate );
                 fs.close();
 

--- a/MzML/Mzml.cpp
+++ b/MzML/Mzml.cpp
@@ -18,6 +18,7 @@
 
 #include <iostream>
 #include <fstream>
+#include <stdlib.h>
 #include "../include/stringhelper.h"
 #include "../include/Sort.h"
 #include "../include/BitConverter.h"
@@ -103,6 +104,10 @@ std::unordered_map<std::string, DissociationType> Mzml::dissociationDictionary =
 
             try{
                 std::ifstream fs = std::ifstream(filePath);
+                if ( !fs.is_open() ) {
+                    std::cout << "could not open file " << filePath << std::endl;
+                    exit (-1);
+                }
                 _indexedmzMLConnection_object = ms::mzml::indexedmzML_ (fs, xml_schema::flags::dont_validate);
                 fs.close();
                 _mzMLConnection = &_indexedmzMLConnection_object.get()->mzML();

--- a/UsefulProteomicsDatabases/ProteinDbLoader.cpp
+++ b/UsefulProteomicsDatabases/ProteinDbLoader.cpp
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <fstream>
 #include <regex>
+#include <stdlib.h>
 
 using namespace Proteomics;
 
@@ -279,7 +280,10 @@ namespace UsefulProteomicsDatabases
 
 		StringBuilder *sb = nullptr;
 		std::ifstream fasta(proteinDbLocation);
-
+                if ( !fasta.is_open() ) {
+                    std::cout << "Could not open file " << proteinDbLocation << std::endl;
+                    exit(-1);
+                }
 		while (true)
 		{
 			std::string line;


### PR DESCRIPTION
this time for mgf, mzml, mzidentml and fasta files.

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>