### PR TITLE
mzlib: add routines to map various enum classes from a string to the …

### DIFF
--- a/MassSpectrometry/MzSpectra/MzSpectrum.cpp
+++ b/MassSpectrometry/MzSpectra/MzSpectrum.cpp
@@ -257,14 +257,13 @@ MzSpectrum::StaticConstructor MzSpectrum::staticConstructor;
                                                            double deconvolutionTolerancePpm,
                                                            double intensityRatioLimit)
     {
-        auto isolatedMassesAndCharges = std::vector<IsotopicEnvelope*>();
+        std::vector<IsotopicEnvelope*> isolatedMassesAndCharges; 
         if (getSize() == 0)  {
             //C# TO C++ CONVERTER TODO TASK: C++ does not have an equivalent to the C# 'yield' keyword:
             //yield break;
             return isolatedMassesAndCharges;
         }
         
-
         for (auto candidateForMostIntensePeak : ExtractIndices(theRange->getMinimum(), theRange->getMaximum()))
         {
             IsotopicEnvelope *bestIsotopeEnvelopeForThisPeak = nullptr;
@@ -303,6 +302,7 @@ MzSpectrum::StaticConstructor MzSpectrum::staticConstructor;
                 for (int indexToLookAt=1; indexToLookAt<(int) allIntensities[massIndex].size(); indexToLookAt++) {
                     double theorMassThatTryingToFind = allMasses[massIndex][indexToLookAt] + differenceBetweenTheorAndActual;
                     auto closestPeakToTheorMass = GetClosestPeakIndex(Chemistry::ClassExtensions::ToMz(theorMassThatTryingToFind, chargeState));
+                    
                     auto closestPeakmz = getXArray()[closestPeakToTheorMass.value()];
                     auto closestPeakIntensity = getYArray()[closestPeakToTheorMass.value()];
                     if (std::abs(Chemistry::ClassExtensions::ToMass(closestPeakmz, chargeState) - theorMassThatTryingToFind) / theorMassThatTryingToFind * 1e6 <= deconvolutionTolerancePpm

--- a/Proteomics/Fragmentation/FragmentationTerminus.h
+++ b/Proteomics/Fragmentation/FragmentationTerminus.h
@@ -32,5 +32,21 @@ namespace Proteomics
             
             return s;
         }
+        static FragmentationTerminus FragmentationTerminusFromString ( std::string s ) {
+            FragmentationTerminus t;
+            if ( s == "Both" ) {
+                t = FragmentationTerminus::Both;
+            }
+            else if ( s == "N" ) {
+                t = FragmentationTerminus::N;
+            }
+            else if ( s == "C" ) {
+                t = FragmentationTerminus::C;
+            }
+            else if ( s == "None" ) {
+                t = FragmentationTerminus::None;
+            }
+            return t;
+        }
     }
 }

--- a/Proteomics/ProteolyticDigestion/InitiatorMethionineBehavior.h
+++ b/Proteomics/ProteolyticDigestion/InitiatorMethionineBehavior.h
@@ -32,6 +32,24 @@ namespace Proteomics
             
             return s;
         }
+
+        static InitiatorMethionineBehavior InitiatorMethionineBehaviorFromString ( std::string s )
+        {
+            InitiatorMethionineBehavior i;
+            if ( s == "Undefined" ) {
+                i = InitiatorMethionineBehavior::Undefined;
+            }
+            else if ( s == "Retain" ) {
+                i = InitiatorMethionineBehavior::Retain;
+            }
+            else if ( s == "Cleave" ) {
+                i = InitiatorMethionineBehavior::Cleave;
+            }
+            else if ( s == "Variable" ) {
+                i = InitiatorMethionineBehavior::Variable;
+            }
+            return i;
+        }
     }
 
     

--- a/UsefulProteomicsDatabases/DecoyType.h
+++ b/UsefulProteomicsDatabases/DecoyType.h
@@ -62,4 +62,26 @@ namespace UsefulProteomicsDatabases
 
         return s;
     }
+
+    static DecoyType DecoyTypeFromString( std::string &s ) {
+        DecoyType t;
+
+        if ( s == "None" ) {
+            t = DecoyType::None;           
+        }
+        else if (  s == "Reverse") {
+            t = DecoyType::Reverse;
+        }
+        else if (  s == "Slide") {
+            t = DecoyType::Slide;
+        }
+        else if (  s == "Shuffle") {
+            t = DecoyType::Shuffle;
+        }
+        else if (  s == "Random") {
+            t = DecoyType::Random;
+        }
+        return t;
+    }
+
 }


### PR DESCRIPTION
…enum

required for the MetaMorpheus toml reading routines.

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>