### PR TITLE
Math.h: remove the LowerGammaRegularized function

### DIFF
--- a/include/Math.h
+++ b/include/Math.h
@@ -97,13 +97,6 @@ public:
         return *d;
     }
 
-    static double GammaLowerRegularized(double globalMeanCount, double score )
-    {
-        double ret = 0.0;
-        std::cout << " Math::GammaLowerRegularized: function is not correctly implemented. Please revisit if nevessary" << std::endl;
-        return ret;
-    }
-
     static double Mean ( std::vector<double> samples )
     {
         if (samples.empty())


### PR DESCRIPTION
was not implemented, and we use now the boost implementation of that function. To be revisited later if necessary

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>