### PR TITLE
add an mzlib_lib_dir in the configure options

### DIFF
--- a/Makefile.defs.in
+++ b/Makefile.defs.in
@@ -11,7 +11,7 @@
 
 MZLIB_DIR      = @mzlib_dir@
 MZLIB_INC_DIR  = $(MZLIB_DIR)/include 
-MZLIB_LIB_DIR  = $(MZLIB_DIR)/lib
+MZLIB_LIB_DIR  = @mzlib_lib_dir@
 MZLIB_LIB      = libmzlib.a
 FLASHLFQ_LIB   = libflashlfq.a
 

--- a/configure
+++ b/configure
@@ -638,6 +638,7 @@ CFLAGS
 CC
 xsdcxx_dir
 libxml2_dir
+mzlib_lib_dir
 mzlib_dir
 LIBOBJS
 EGREP
@@ -694,6 +695,7 @@ ac_user_opts='
 enable_option_checking
 enable_debug
 with_mzlib_dir
+with_mzlib_lib_dir
 with_libxml2_dir
 with_xsdcxx_dir
 with_gnu_ld
@@ -1333,6 +1335,7 @@ Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
   --with-mzlib-dir=dir            Main mzLib directory (default=$PWD)
+  --with-mzlib-lib_dir=dir            mzLib lib directory (default=mzlib_dir/lib)
   --with-libxml2-dir=dir          libxml2 directory (default=/usr/include/libxml2/)
   --with-xsdcxx-dir=dir          xsdcxx directory (default=/usr/include)
   --with-gnu-ld           assume the C compiler uses GNU ld [default=no]
@@ -3761,6 +3764,24 @@ fi
          fi
      { $as_echo "$as_me:${as_lineno-$LINENO}: result: ${mzlib_dir}" >&5
 $as_echo "${mzlib_dir}" >&6; }
+
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for mzLib lib directory" >&5
+$as_echo_n "checking for mzLib lib directory... " >&6; }
+
+# Check whether --with-mzlib_lib_dir was given.
+if test "${with_mzlib_lib_dir+set}" = set; then :
+  withval=$with_mzlib_lib_dir; mzlib_lib_dir="${withval}"
+else
+  mzlib_lib_dir=""
+fi
+
+         if test "x$mzlib_lib_dir" = "x" ; then
+                mzlib_lib_dir="$mzlib_dir"/lib
+         fi
+     { $as_echo "$as_me:${as_lineno-$LINENO}: result: ${mzlib_lib_dir}" >&5
+$as_echo "${mzlib_lib_dir}" >&6; }
+
 
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for libxml2" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -80,6 +80,19 @@ AC_ARG_WITH(mzlib_dir,
 dnl ==================================================
 
 dnl ==================================================
+AC_MSG_CHECKING(for mzLib lib directory)
+AC_ARG_WITH(mzlib_lib_dir,
+ [  --with-mzlib-lib_dir=dir            mzLib lib directory (default=mzlib_dir/lib)],
+     mzlib_lib_dir="${withval}", mzlib_lib_dir="")
+         if test "x$mzlib_lib_dir" = "x" ; then
+                mzlib_lib_dir="$mzlib_dir"/lib
+         fi
+     AC_MSG_RESULT(${mzlib_lib_dir})
+     AC_SUBST(mzlib_lib_dir)
+dnl ==================================================
+
+
+dnl ==================================================
 AC_MSG_CHECKING(for libxml2)
 AC_ARG_WITH(libxml2_dir,
  [  --with-libxml2-dir=dir          libxml2 directory (default=/usr/include/libxml2/)],


### PR DESCRIPTION
not necessarily needed by standalone mzlib library, but will be used
by HPCMetaMorpheus to unify the location of the libraries.

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>