### PR TITLE
Makefile: make clean should also include TestSerialization

### DIFF
--- a/Test/Makefile
+++ b/Test/Makefile
@@ -119,3 +119,4 @@ clean:
 	rm -f TestPeptides TestAminoAcids TestModifications TestFragments TestMetaMorpheus
 	rm -f TestProteinDigestion TestProteinProperties TestSpectra TestMzML TestMgf
 	rm -f TestPeptideWithSetMods TestPtmListLoader TestModFits TestChromatogram
+	rm -f TestSerialization


### PR DESCRIPTION
Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>