### PR TITLE
PeptideWithSetModifications.cpp: add another version of SetNonSeriali…

### DIFF
--- a/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cpp
+++ b/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cpp
@@ -546,6 +546,24 @@ namespace Proteomics
             //GetDigestionParamsAfterDeserialization(); 
         }
 
+        void PeptideWithSetModifications::SetNonSerializedPeptideInfo(std::vector<Proteomics::Protein*> &proteinList)
+        {
+            std::string accession = getProteinAccession();
+            Proteomics::Protein *prot=nullptr;
+            for ( auto p : proteinList ) {
+                if ( p->getAccession() == accession ) {
+                    prot = p;
+                    break;
+                }
+            }            
+            setProtein(prot);
+
+            //only used to reconstruct _baseSequence 
+            std::unordered_map<std::string, Modification*> idToMod;       
+            GetModsAfterDeserialization(idToMod, _baseSequence);
+        }
+        
+        
         void PeptideWithSetModifications::GetDigestionParamsAfterDeserialization()
         {
             if (DigestionParamString != "")

--- a/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.h
+++ b/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.h
@@ -175,6 +175,11 @@ namespace Proteomics
                                              std::unordered_map<std::string, Proteomics::Protein*> &accessionToProtein);
 
 
+            /// <summary>
+            /// Alternative version of the function above, used by MetaMorpheus CrosslinkSpectral match deserialization
+            /// </summary>
+            void SetNonSerializedPeptideInfo ( std::vector<Proteomics::Protein *> &proteinList );
+            
         private:
             void GetDigestionParamsAfterDeserialization();
 


### PR DESCRIPTION
…zedPeptideInfo

this version is required for the (De)Serialization of a CrosslinkSpectralMatch in MetaMorpheus.

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>