### PR TITLE
PeptideWithSetModifications.cpp: add const qualifyer

### DIFF
--- a/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cpp
+++ b/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cpp
@@ -546,7 +546,7 @@ namespace Proteomics
             //GetDigestionParamsAfterDeserialization(); 
         }
 
-        void PeptideWithSetModifications::SetNonSerializedPeptideInfo(std::vector<Proteomics::Protein*> &proteinList)
+        void PeptideWithSetModifications::SetNonSerializedPeptideInfo(const std::vector<Proteomics::Protein*> &proteinList)
         {
             std::string accession = getProteinAccession();
             Proteomics::Protein *prot=nullptr;

--- a/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.h
+++ b/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.h
@@ -178,7 +178,7 @@ namespace Proteomics
             /// <summary>
             /// Alternative version of the function above, used by MetaMorpheus CrosslinkSpectral match deserialization
             /// </summary>
-            void SetNonSerializedPeptideInfo ( std::vector<Proteomics::Protein *> &proteinList );
+            void SetNonSerializedPeptideInfo ( const std::vector<Proteomics::Protein *> &proteinList );
             
         private:
             void GetDigestionParamsAfterDeserialization();


### PR DESCRIPTION
for the new SetNonSerializedPeptideInfo method to match the
approach in HPCMetaMorpheus

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>