### PR TITLE
PeptideWithSetModifications.cpp: fix generation of _basesequence

### DIFF
--- a/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cpp
+++ b/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cpp
@@ -606,6 +606,9 @@ namespace Proteomics
                         bracketCount--;
 
                         if ( idToMod.size() == 0 ) {
+                            if ( bracketCount == 0 ) {
+                                currentlyReadingMod = false;
+                            }
                             // not meant to identify mods, just called form the constructor
                             // without a valid Mods table. Just use to construct the base sequence.
                             break;


### PR DESCRIPTION
when _basesequence is constructed in GetModsAfterDeserialization, there was a minor bug
that prevented the basesequence to be calculated correctly after a Mod.

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>