### PR TITLE
BinaryPack: make the API more userfriendly

### DIFF
--- a/Proteomics/Fragmentation/MatchedFragmentIon.cpp
+++ b/Proteomics/Fragmentation/MatchedFragmentIon.cpp
@@ -93,6 +93,7 @@ namespace Proteomics
                     buf_len = pos + len;
                     return ret;
                 }
+                
                 pos += len;
             }
             buf_len = pos;
@@ -101,12 +102,11 @@ namespace Proteomics
         
         int MatchedFragmentIon::Pack(char *buf, size_t &buf_len, MatchedFragmentIon *MaF)
         {
-            int tmplen = 256;
             char tmpbuf[256];
-            size_t retlen;
+            size_t retlen=0;
 
             // Initial position is sizeof(int), since we will copy the overall length at the beginning.
-            size_t pos=sizeof(int);
+            size_t pos=BinaryPack::LineStartOffset;
             
             retlen = BinaryPack::PackDouble(tmpbuf+pos, MaF->Mz);
             pos += retlen;
@@ -133,8 +133,8 @@ namespace Proteomics
             pos += retlen;
 
             // Last step: save the total size of the line at the beginning. We reserved the memory for that.
-            retlen = BinaryPack::PackInt(tmpbuf, (int)pos);
-            
+            BinaryPack::SetLineLength(tmpbuf, (int)pos);
+
             if ( pos > buf_len )  {
                 buf_len = pos;
                 return -1;
@@ -143,6 +143,7 @@ namespace Proteomics
                 buf_len = pos;
                 memcpy (buf, tmpbuf, pos );
             }
+            
             return (int)pos;            
         }
 
@@ -151,8 +152,6 @@ namespace Proteomics
                                         std::vector<MatchedFragmentIon *> &newMaFVec,
                                         int count )
         {
-            //std::string input_buf (buf);
-            //std::vector<std::string> lines = StringHelper::split(input_buf, '\n');
             std::vector<char *>lines = BinaryPack::SplitLines(buf, buf_len);
             
             size_t total_len=0;
@@ -179,7 +178,7 @@ namespace Proteomics
             size_t retlen, pos=0;
 
             int total_len;
-            retlen = BinaryPack::UnpackInt(input, total_len);
+            retlen = BinaryPack::GetLineLength(input+pos, total_len);
             pos += retlen;
             
             double mz, intensity;

--- a/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cpp
+++ b/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cpp
@@ -785,9 +785,10 @@ namespace Proteomics
             char tmpbuf[256];
 
             // leave space for the length of the line
-            size_t pos=sizeof(int);
+            size_t pos = BinaryPack::LineStartOffset;
             
-            size_t bufpos = 0; // Since we store multiple lines, we need to keep track of the buf position as well.
+            // Since we store multiple lines, we need to keep track of the buf position as well.
+            size_t bufpos = 0; 
             
             retlen = BinaryPack::PackInt( tmpbuf+pos, pep->getOneBasedStartResidueInProtein() );
             pos += retlen;
@@ -803,7 +804,7 @@ namespace Proteomics
             pos += retlen;
 
             //now save the length of this line at the beginning of the file.
-            retlen = BinaryPack::PackInt(tmpbuf, (int)pos);
+            BinaryPack::SetLineLength(tmpbuf, (int)pos);
             if ( (pos + bufpos) > size ) {
                 size = pos+bufpos;
                 return -1;
@@ -813,14 +814,14 @@ namespace Proteomics
             bufpos += pos;
 
             // line 2: FullSequence
-            pos = sizeof(int);
+            pos = BinaryPack::LineStartOffset;
             memset (tmpbuf, 0, 256);
 
             retlen = BinaryPack::PackString(tmpbuf+pos,pep->getFullSequence() );
             pos += retlen;
 
             //now save the length of this line at the beginning of the file.
-            retlen = BinaryPack::PackInt(tmpbuf, (int)pos);
+            BinaryPack::SetLineLength(tmpbuf, (int)pos);
             if ( (pos + bufpos) > size ) {
                 size = pos+bufpos;
                 return -1;
@@ -829,14 +830,14 @@ namespace Proteomics
             bufpos += pos;
             
             // line 3: DigestionParams
-            pos = sizeof(int);
+            pos = BinaryPack::LineStartOffset;
             memset (tmpbuf, 0, 256);
 
             retlen = BinaryPack::PackString(tmpbuf+pos,pep->getDigestionParamString() );
             pos += retlen;
             
             //now save the length of this line at the beginning of the file.
-            retlen = BinaryPack::PackInt(tmpbuf, (int)pos);
+            BinaryPack::SetLineLength(tmpbuf, (int)pos);
             if ( (pos + bufpos) > size ) {
                 size = pos+bufpos;
                 return -1;
@@ -846,7 +847,7 @@ namespace Proteomics
             bufpos += pos;
 
             // line4: ProteinAccession
-            pos = sizeof(int);
+            pos = BinaryPack::LineStartOffset;
             memset (tmpbuf, 0, 256);
 
             std::string accession = pep->getProteinAccession();
@@ -857,7 +858,7 @@ namespace Proteomics
             pos += retlen;
 
             //now save the length of this line at the beginning of the file.
-            retlen = BinaryPack::PackInt(tmpbuf, (int)pos);
+            BinaryPack::SetLineLength(tmpbuf, (int)pos);
             if ( (pos + bufpos) > size ) {
                 size = pos+bufpos;
                 return -1;
@@ -959,7 +960,7 @@ namespace Proteomics
             int line_len=0;
             char *buf = input[index];
 
-            retlen = BinaryPack::UnpackInt(buf+pos, line_len );
+            retlen = BinaryPack::GetLineLength(buf+pos, line_len );
             pos += retlen;
             total_len += line_len;
             
@@ -987,7 +988,7 @@ namespace Proteomics
             pos = 0;
             buf = input[index+1];
 
-            retlen = BinaryPack::UnpackInt(buf+pos, line_len );
+            retlen = BinaryPack::GetLineLength(buf+pos, line_len );
             pos += retlen;
             total_len += line_len;
 
@@ -998,7 +999,7 @@ namespace Proteomics
             // Processing line 3
             pos = 0;
             buf = input[index+2];
-            retlen = BinaryPack::UnpackInt(buf+pos, line_len );
+            retlen = BinaryPack::GetLineLength(buf+pos, line_len );
             pos += retlen;
             total_len += line_len;
 
@@ -1014,7 +1015,7 @@ namespace Proteomics
             // Processing line 4
             pos = 0;
             buf = input[index+3];
-            retlen = BinaryPack::UnpackInt(buf+pos, line_len );
+            retlen = BinaryPack::GetLineLength(buf+pos, line_len );
             pos += retlen;
             total_len += line_len;
 

--- a/include/BinaryPack.h
+++ b/include/BinaryPack.h
@@ -3,16 +3,20 @@
 #include <cstdint>
 #include <string>
 #include <string.h>
-
+#include <iostream>
 
 class BinaryPack {
+private:
+    static const int16_t BinaryPackHeader=0xABCD;
+    
 public:
+    static const int LineStartOffset = sizeof(int16_t)+sizeof(int);
+
     static size_t PackFloat ( char *buf, const float &val)
     {
         memcpy ( buf, &val, sizeof(float));
         return sizeof(float);
     }
-
     static size_t UnpackFloat ( char* buf, float &val)
     {
         memcpy (&val, buf, sizeof(float));
@@ -24,7 +28,6 @@ public:
         memcpy ( buf, &val, sizeof(double));
         return sizeof(double);
     }
-
     static size_t UnpackDouble ( char *buf, double &val)
     {
         memcpy ( &val, buf, sizeof(double));
@@ -36,11 +39,21 @@ public:
         memcpy ( buf, &val, sizeof(int));
         return sizeof(int);
     }
-
     static size_t UnpackInt ( char *buf, int &val)
     {
         memcpy ( &val, buf, sizeof(int));
         return sizeof(int);
+    }
+
+    static size_t PackBool ( char *buf, const bool &val)
+    {
+        memcpy ( buf, &val, sizeof(bool));
+        return sizeof(bool);
+    }
+    static size_t UnpackBool ( char *buf, bool &val)
+    {
+        memcpy ( &val, buf, sizeof(bool));
+        return sizeof(bool);
     }
     
     static size_t PackString ( char *buf, const std::string &val)
@@ -68,16 +81,47 @@ public:
     {
         std::vector<char *> tvec;
         size_t pos=0;
+        int16_t header;
         while ( pos < buf_len ) {
             int linelen, retlen;
 
             char *tpos = &buf[pos];
             tvec.push_back(tpos);
-            retlen = BinaryPack::UnpackInt (buf+pos, linelen);
+            memcpy(&header, buf+pos, sizeof(int16_t));
+            if ( header != BinaryPackHeader ) {
+                std::cout <<"Memory corruption detected in BinaryPack::SplitLines\n";
+                tvec.clear();
+                return tvec;
+            }
+            retlen = BinaryPack::UnpackInt (buf+pos+sizeof(int16_t), linelen);
             pos += linelen;            
         }
         
         return tvec;
+    }
+
+    static void SetLineLength( char *buf, const int &len)
+    {
+        // Copy first a 2byte header to the beginning  of the line.
+        // Allows to identify memory corruption easier.
+        memcpy(buf, &BinaryPackHeader, sizeof(int16_t));
+        memcpy(buf+sizeof(int16_t), &len, sizeof(int));
+    }
+
+    static int GetLineLength( char *buf, int &linelen)
+    {
+        int retlen;
+        int16_t header;
+        int pos=0;
+        memcpy(&header, buf+pos, sizeof(int16_t));
+        if ( header != BinaryPackHeader ) {
+            std::cout <<"Memory corruption detected in BinaryPack::GetLineLength\n";
+            return -1;
+        }
+        pos += sizeof(int16_t);
+        retlen = BinaryPack::UnpackInt (buf+pos, linelen);
+        
+        return pos+retlen;
     }
     
 };


### PR DESCRIPTION
a small 2-byte header will help to detect memory corruption more easily.

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>