### PR TITLE
PeptideWithSetModifications.cpp: change interface to SetNonSerialized…

### DIFF
--- a/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cpp
+++ b/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.cpp
@@ -550,7 +550,8 @@ namespace Proteomics
             //GetDigestionParamsAfterDeserialization(); 
         }
 
-        void PeptideWithSetModifications::SetNonSerializedPeptideInfo(const std::vector<Proteomics::Protein*> &proteinList)
+        void PeptideWithSetModifications::SetNonSerializedPeptideInfo(const std::vector<Modification *> &modList, 
+                                                                      const std::vector<Proteomics::Protein*> &proteinList)
         {
             std::string accession = getProteinAccession();
             Proteomics::Protein *prot=nullptr;
@@ -562,8 +563,10 @@ namespace Proteomics
             }            
             setProtein(prot);
 
-            //only used to reconstruct _baseSequence 
-            std::unordered_map<std::string, Modification*> idToMod;       
+            std::unordered_map<std::string, Modification*> idToMod;
+            for ( auto mod : modList ) {
+                idToMod.emplace( mod->getIdWithMotif(), mod);
+            }
             GetModsAfterDeserialization(idToMod, _baseSequence);
         }
         

--- a/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.h
+++ b/Proteomics/ProteolyticDigestion/PeptideWithSetModifications.h
@@ -178,7 +178,8 @@ namespace Proteomics
             /// <summary>
             /// Alternative version of the function above, used by MetaMorpheus CrosslinkSpectral match deserialization
             /// </summary>
-            void SetNonSerializedPeptideInfo ( const std::vector<Proteomics::Protein *> &proteinList );
+            void SetNonSerializedPeptideInfo (const std::vector<Modification*> &modList,       
+                                              const std::vector<Proteomics::Protein *> &proteinList );
             
         private:
             void GetDigestionParamsAfterDeserialization();


### PR DESCRIPTION
…PeptideInfo

the version that is used in CrosslinkSpectralMatch::UNpack requires a slightly different
interface in order to reconstruct the Mods correctly.

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>